### PR TITLE
UNIX/Linux build and other fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,13 @@ CURSES_INC=$(shell pkg-config --variable=includedir ncurses)
 CURSES_LIBS=$(shell pkg-config --libs ncurses)
 CC=gcc
 CPP=$(CC) -E
-CFLAGS=-std=c11 -pedantic -Wall -O2 -I$(CURSES_INC) -DBSD -Werror=all -Wno-error=unused-but-set-variable
+OMEGA_CFLAGS=-std=c11 -pedantic -Wall
+OMEGA_CPPFLAGS=-std=c11 -I$(CURSES_INC) -DBSD
+OMEGA_LDFLAGS=-L. $(CURSES_LIBS)
+CFLAGS+=$(OMEGA_CFLAGS)
+CPPFLAGS+=$(OMEGA_CPPFLAGS)
+LDFLAGS+=$(OMEGA_LDFLAGS)
 
-LDFLAGS=-L. $(CURSES_LIBS)
 
 SOURCES = omega.c abyss.c aux1.c aux2.c aux3.c bank.c char.c city.c clrgen.c\
       command1.c command2.c command3.c country.c date.c effect1.c\
@@ -23,7 +27,7 @@ OBJ = omega.o abyss.o aux1.o aux2.o aux3.o bank.o char.o city.o clrgen.o\
       stats.o time.o trap.o util.o village.o
 
 all: maps genclr clrgen.o date $(OBJ)
-	$(CC) $(CFLAGS) $(OBJ) $(LDFLAGS) -o omega
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(OBJ) $(LDFLAGS) $(LIBS) -o omega
 
 maps:
 	$(CC) tools/crypt.c    -o tools/crypt
@@ -36,8 +40,8 @@ date: tools/makedate
 	tools/makedate > date.c
 
 genclr: genclr.o
-	$(CC) $(LDFLAGS) genclr.o -o genclr
-	$(CPP) $(CFLAGS) -DOMEGA_CLRGEN *.[ch] | ./genclr clrgen.c clrgen.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(LIBS) genclr.o -o genclr
+	$(CPP) $(CPPFLAGS) $(CFLAGS) -DOMEGA_CLRGEN *.[ch] | ./genclr clrgen.c clrgen.h
 
 tools/makedate: tools/makedate.c
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-CURSES_INC=/home/Ivan/PDCurses-3.4
+CURSES_INC=$(shell pkg-config --variable=includedir ncurses)
+CURSES_LIBS=$(shell pkg-config --libs ncurses)
 CC=gcc
 CPP=$(CC) -E
-CFLAGS=-std=c11 -ansi -pedantic -Wall -O2 -I$(CURSES_INC)
-LDFLAGS=-L. -lpdcurses
+CFLAGS=-std=c11 -pedantic -Wall -O2 -I$(CURSES_INC) -DBSD -Werror=all -Wno-error=unused-but-set-variable
+
+LDFLAGS=-L. $(CURSES_LIBS)
 
 SOURCES = omega.c abyss.c aux1.c aux2.c aux3.c bank.c char.c city.c clrgen.c\
       command1.c command2.c command3.c country.c date.c effect1.c\
@@ -30,16 +32,22 @@ maps:
 	tools/crypt tools/libsrc/maps.dat tools/libsrc/*.map
 	cp tools/libsrc/maps.dat lib/maps.dat
 
-date:
+date: tools/makedate
 	tools/makedate > date.c
 
 genclr: genclr.o
 	$(CC) $(LDFLAGS) genclr.o -o genclr
 	$(CPP) $(CFLAGS) -DOMEGA_CLRGEN *.[ch] | ./genclr clrgen.c clrgen.h
 
+tools/makedate: tools/makedate.c
+
+clrgen.c clrgen.h: genclr
+
 clrgen.o: clrgen.c
 
 date.o: date.c
+
+$(SOURCES): clrgen.h
 
 clean:
 	rm -f tools/libsrc/maps.dat

--- a/bank.c
+++ b/bank.c
@@ -2,10 +2,10 @@
 /* bank.c */
 /* new bank -- moved out of site1.c */
 
+#include "glob.h"
 #include <ctype.h>
 #include <limits.h>
 #include <unistd.h>
-#include "glob.h"
 
 /* swiped from scr.c */
 #if defined(MSDOS_SUPPORTED_ANTIQUE) || defined(AMIGA)

--- a/char.c
+++ b/char.c
@@ -2,13 +2,15 @@
 /* char.c */
 /* Player generation */
 
+#include "glob.h"
+
 #ifndef MSDOS_SUPPORTED_ANTIQUE
 #include <sys/types.h>
 #include <unistd.h>
-/* #include <pwd.h> */
+#ifndef __WIN32
+#include <pwd.h>
 #endif
-
-#include "glob.h"
+#endif
 
 /* set player to begin with */
 int initplayer(void)

--- a/command1.c
+++ b/command1.c
@@ -276,7 +276,7 @@ void p_country_process(void)
     case 18: redraw(); no_op = TRUE; break; /* ^r */
     case 23: if (gamestatusp(CHEATED)) drawscreen();  break; /* ^w */
     case 24: if (gamestatusp(CHEATED) || 
-		 Player.rank[ADEPT]) wish(1);  break; /* ^x */
+		 Player.rank[ADEPT]) { wish(1);  break; } /* ^x */
     case 'd': drop();  break;
     case 'e': eat();  break;
     case 'i': 

--- a/defs.h
+++ b/defs.h
@@ -126,6 +126,9 @@ on save and restore. */
  * but my compiler seems to disagree unless this is set.  I hope that
  * this doesn't break too many things. */
 /*#define __USE_POSIX2*/
+#define _DEFAULT_SOURCE
+#define _POSIX_C_SOURCE 2
+#define _XOPEN_SOURCE 500
 
 #if defined(MSDOS_SUPPORTED_ANTIQUE)
 #define SAVE_LEVELS

--- a/defs.h
+++ b/defs.h
@@ -73,6 +73,11 @@ on save and restore. */
 
 #define OMEGALIB "./lib/"
 
+/* OMEGASTATE is where all the volatile data files reside. 
+   Notes as above apply. */
+
+#define OMEGASTATE "./lib/"
+
 /* TILEFILE is the name of the file you want to use for graphics tiles. You */
 /* aren't really free to use any file you want here. It should be the Omega */
 /* distribution graphics files provided for your computer. Of course a file */

--- a/defs.h
+++ b/defs.h
@@ -127,7 +127,6 @@ on save and restore. */
  * this doesn't break too many things. */
 /*#define __USE_POSIX2*/
 #define _DEFAULT_SOURCE
-#define _POSIX_C_SOURCE 2
 #define _XOPEN_SOURCE 500
 
 #if defined(MSDOS_SUPPORTED_ANTIQUE)

--- a/file.c
+++ b/file.c
@@ -160,7 +160,7 @@ void lock_score_file(void)
 
   FILE * lockfile;
 
-  strcpy(Str1,Omegalib);
+  strcpy(Str1,Omegastate);
   strcat(Str1,"omega.hi.lock");
 
   do
@@ -206,7 +206,7 @@ void lock_score_file(void)
 void unlock_score_file(void)
 {
 #ifndef MSDOS
-    strcpy(Str1,Omegalib);
+    strcpy(Str1,Omegastate);
     strcat(Str1,"omega.hi.lock");
     unlink(Str1);
 #endif
@@ -218,7 +218,7 @@ void showscores(void)
   int i;
 
   lock_score_file();
-  strcpy(Str1,Omegalib);
+  strcpy(Str1,Omegastate);
   strcat(Str1,"omega.hi");
   fd = checkfopen(Str1,"rb");
   filescanstring(fd,Hiscorer);
@@ -302,10 +302,10 @@ void save_hiscore_npc(int npc)
   if (gamestatusp(CHEATED))
       return;
   lock_score_file();
-  strcpy(Str1,Omegalib);
+  strcpy(Str1,Omegastate);
   strcat(Str1,"omega.hi");
   infile = checkfopen(Str1,"rb");
-  strcpy(Str2,Omegalib);
+  strcpy(Str2,Omegastate);
 #ifdef MSDOS
   strcat(Str2,"omegahi.new");	/* stupid 8.3 msdos filename limit */
 #else
@@ -434,7 +434,7 @@ void extendlog(char *descrip, int lifestatus)
     change_to_game_perms();
     npcbehavior=fixnpc(lifestatus);
     checkhigh(descrip,npcbehavior);
-    strcpy(Str1,Omegalib);
+    strcpy(Str1,Omegastate);
     strcat(Str1,"omega.log");
     fd = checkfopen(Str1,"a");
     fprintf(fd, " %d %d %d %s\n", lifestatus, Player.level, npcbehavior,
@@ -494,10 +494,16 @@ int test_file_access(char *file_name, char mode)
 }
 #endif
 
-char *required_file_list[] =
+char *required_lib_file_list[] =
 {
-  "maps.dat", "omega.hi", "omega.log", "motd.txt",
+  "maps.dat", "motd.txt",
   "license.txt", NULL
+};
+
+char *required_state_file_list[] =
+{
+  "omega.hi", "omega.log",
+  NULL
 };
 
 char *optional_file_list[] =
@@ -516,19 +522,30 @@ int filecheck(void)
     int endpos;
     int file;
 
-    strcpy(Str1, Omegalib);
+    strcpy(Str1, Omegastate);
     endpos = strlen(Str1);
-    for (file = 0; required_file_list[file]; file++)
+    for (file = 0; required_state_file_list[file]; file++)
     {
-	strcpy(&(Str1[endpos]), required_file_list[file]);
-	if ((strcmp(required_file_list[file], "omega.hi") == 0 ||
-	    strcmp(required_file_list[file], "omega.log") == 0) &&
+	strcpy(&(Str1[endpos]), required_state_file_list[file]);
+	if ((strcmp(required_state_file_list[file], "omega.hi") == 0 ||
+	    strcmp(required_state_file_list[file], "omega.log") == 0) &&
 	    test_file_access(Str1, 'w') == 0)
 	{
 	    impossible = TRUE;
 	    printf("\nError! File not appendable or accessible: %s", Str1);
 	}
 	else if (test_file_access(Str1, 'r') == 0)
+	{
+	    impossible = TRUE;
+	    printf("\nError! File not accessible: %s", Str1);
+	}
+    }
+    strcpy(Str1, Omegalib);
+    endpos = strlen(Str1);
+    for (file = 0; required_lib_file_list[file]; file++)
+    {
+	strcpy(&(Str1[endpos]), required_lib_file_list[file]);
+	if (test_file_access(Str1, 'r') == 0)
 	{
 	    impossible = TRUE;
 	    printf("\nError! File not accessible: %s", Str1);

--- a/glob.h
+++ b/glob.h
@@ -26,6 +26,9 @@ extern char SaveFileName[80];
 /* This string holds the path to the library files */
 extern char *Omegalib;
 
+/* This string holds the path to the volatile files */
+extern char *Omegastate;
+
 /* one of each monster */
 extern struct monster Monsters[NUMMONSTERS];
 

--- a/lib/license.txt
+++ b/lib/license.txt
@@ -59,3 +59,14 @@ friendlier user interface, more puzzles, or any other topic you'd like to
 see addressed, please write to William.  Every suggestion's fair game; it's
 been too long since Omega's gotten the respect that it deserves.  Feel free
 to check for the latest version at http://lyric.ml.org/~wtanksle/omega/.
+
+====
+Above contact information is historical only
+
+0.91 prealpha was distributed and maintained by muspellsson@undeadbsd.org
+(Ivan Sukin).  Given lack of activity since 2017, I have now taken over
+maintainership. 
+
+Current version Omega, 0.91 prealpha 2, is distributed and maintained by
+steve@snewbury.org.uk (Steven Newbury). Please report issues and/or pull
+requests via https://github.com/sjnewbury/omega-ng

--- a/lib/motd.txt
+++ b/lib/motd.txt
@@ -11,11 +11,11 @@
 
             omega version 0.91 is copyright (C) 1987,1988,1989 by:
                              Laurence R. Brothers
-                                  copyright (C) 2016 by:
-                             Ivan Sukin
+                                  copyright (C) 2016-2021 by:
+                             Ivan Sukin, Steven Newbury
                        and is licensed under the LGPL.
-             Maintained by: Ivan Sukin (muspellsson@undeadbsd.org).
+             Maintained by: Steven Newbury (steve@snewbury.org.uk).
              Send suggestions and complaints about this prealpha to
-                         Ivan Sukin, or visit
-                     https://github.com/muspellsson/omega-ng.
+                         Steven Newbury, or visit
+                     https://github.com/sjnewbury/omega-ng
 

--- a/omega.c
+++ b/omega.c
@@ -22,6 +22,7 @@
 /* most globals originate in omega.c */
 
 char *Omegalib;		/* contains the path to the library files */
+char *Omegastate;	/* contains the path to the volatile files */
 
 #ifdef DEBUG
 FILE *DG_debug_log; /* debug log file pointer */
@@ -357,6 +358,8 @@ int main(int argc, char *argv[])
   if (!(Omegalib = getenv("OMEGALIB")))
 #endif
     Omegalib = OMEGALIB;
+
+  Omegastate = OMEGASTATE;
 
   /* if filecheck is 0, some necessary data files are missing */
   if (filecheck() == 0) exit(0);

--- a/scr.c
+++ b/scr.c
@@ -4,6 +4,8 @@
 /* plus a few file i/o stuff */
 /* also some in file.c */
 
+#include "glob.h"
+
 #ifdef MSDOS_SUPPORTED_ANTIQUE
 # include "curses.h"
 #else
@@ -23,7 +25,6 @@
 # define CHARATTR(c)	((c) & ~0xff)
 #endif
 
-#include "glob.h"
 #include <ctype.h>
 #include <unistd.h>
 

--- a/site1.c
+++ b/site1.c
@@ -2,11 +2,11 @@
 /* site1.c */
 /* 1st half of site functions and aux functions to them */
 
+#include "glob.h"
+
 #ifndef MSDOS_SUPPORTED_ANTIQUE
 #include <unistd.h>
 #endif
-
-#include "glob.h"
 
 void l_armorer(void)
 {

--- a/site2.c
+++ b/site2.c
@@ -229,7 +229,7 @@ void pacify_guards(void)
 	Level->site[ml->m->x][ml->m->y].creature = ml->m;
       }
     }
-    if (Current_Environment == E_CITY)
+  if (Current_Environment == E_CITY)
       Level->site[40][60].p_locf = L_ORDER; /* undoes action in alert_guards */
 }
 

--- a/util.c
+++ b/util.c
@@ -3,6 +3,8 @@
 
 /* Random utility functions called from all over */
 
+#include "glob.h"
+
 #ifndef MSDOS_SUPPORTED_ANTIQUE
 #include <sys/types.h>
 #include <sys/time.h>
@@ -13,8 +15,6 @@ int setreuid(uid_t ruid, uid_t euid);
 #endif
 #include <stdlib.h>
 #endif
-
-#include "glob.h"
 
 void setPlayerXY(int x, int y)
 {


### PR DESCRIPTION
This gets things working on fully up to date Gentoo Linux with GCC-6.3.0.  There are still warnings which should be addressed, mostly not checking the return value of various functions. 

The only contentious part of this patch series is the inclusion of -DBSD which is obviously not correct for Windows builds.  It was the old default though.  It probably should have it's own variable in the make file to make it clearer that it needs to be changed depending on build system.
